### PR TITLE
Add an on click handler to prevent default

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -150,7 +150,8 @@
                 >
                 {#if codeOutput !== ""}
                     <a href={codeOutput} class="button button-bookmarklet"
-                       on:click={(e) => ( e.preventDefault())}>{bookmarkletName}</a>
+                       on:click={(e) => ( e.preventDefault())}>{bookmarkletName}</a
+                    >
                 {/if}
             </div>
         </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -150,8 +150,7 @@
                 >
                 {#if codeOutput !== ""}
                     <a href={codeOutput} class="button button-bookmarklet"
-                        >{bookmarkletName}</a
-                    >
+                       on:click={(e) => ( e.preventDefault())}>{bookmarkletName}</a>
                 {/if}
             </div>
         </div>


### PR DESCRIPTION
First off thank you for this tool, it will be a part of my bookmarklet workflow going forward. 
I too love bookmarklets, a lot 🧡. 

Hopefully you are open to contribs. 
I found that with the first example to make page editable, when I accidentally clicked on the bookmarklet button (instead of dragging it, like I was supposed to) I made the page unusable and couldn't drag the button anymore, I had to refresh. But that was confusing and took me awhile to realize what I had done.

I had thought about this behavior a bit while thinking of creating a bookmarklet library myself for sharing my favorites and thought maybe an on click handler could prevent that. 

I tested it with your project and it does seem to fix this issue. 
I think you will want to improve it with messaging to let the user know why clicking on the bookmarklet didn't do anything. 
Or maybe clicking it should copy it? not sure that is any easier. 
